### PR TITLE
Add pure player-identification module (colour-code decoding)

### DIFF
--- a/backend/identity/__init__.py
+++ b/backend/identity/__init__.py
@@ -1,0 +1,52 @@
+"""Pure-Python player identification via colour-code decoding.
+
+This package is **deliberately dependency-free and decoupled** from the
+database, the web layer, and the vision/LLM call. It maps the colours a
+player wears (across "channels" such as shirt / head / armband) onto a
+unique player identity, robustly against a hidden item (erasure) or a
+misread colour.
+
+See ``docs/team_photo_identification_plan.md`` for the full design brief.
+
+Layering (each module depends only on the ones above it):
+
+    galois        -> GF(p) prime-field arithmetic
+    code          -> LinearCode (parity / Reed-Solomon) over GF(q)
+    channels      -> Channel / ChannelSet (physical label <-> index)
+    observations  -> per-channel readings + priors
+    scheme        -> IdentityScheme (binds channels + code + assignment)
+    decoder       -> soft decoder (readings + prior -> ranked posteriors)
+    config        -> the declarative initial config + default_scheme()
+"""
+
+from backend.identity.channels import Channel
+from backend.identity.channels import ChannelSet
+from backend.identity.code import LinearCode
+from backend.identity.code import build_code
+from backend.identity.code import parity_code
+from backend.identity.code import reed_solomon_code
+from backend.identity.config import DEFAULT_PALETTE
+from backend.identity.config import default_scheme
+from backend.identity.decoder import DecodeResult
+from backend.identity.decoder import decode
+from backend.identity.observations import ChannelObservation
+from backend.identity.observations import Prior
+from backend.identity.observations import Reading
+from backend.identity.scheme import IdentityScheme
+
+__all__ = [
+    "Channel",
+    "ChannelSet",
+    "LinearCode",
+    "build_code",
+    "parity_code",
+    "reed_solomon_code",
+    "DEFAULT_PALETTE",
+    "default_scheme",
+    "DecodeResult",
+    "decode",
+    "ChannelObservation",
+    "Prior",
+    "Reading",
+    "IdentityScheme",
+]

--- a/backend/identity/channels.py
+++ b/backend/identity/channels.py
@@ -1,0 +1,128 @@
+"""Channels and channel sets: the bridge between physical symbols and
+``GF(q)`` indices.
+
+A :class:`Channel` is one categorical feature the vision model can read
+independently (shirt colour, head colour, armband colour -- or, in future, a
+*shape* printed on the shirt). Its ``labels`` are the ordered physical symbol
+names. Different channels may carry **different** alphabets (colours vs shapes)
+as long as each supplies at least ``q`` symbols, because the algebraic code only
+ever sees the index ``[0, q)``, never the physical meaning.
+
+A :class:`ChannelSet` is the ordered tuple of channels for a scheme; its length
+must equal the code's ``n``. It converts between a codeword (tuple of indices)
+and an *appearance* dict ``{channel_name: label}`` -- i.e. "what the player
+physically wears".
+"""
+
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Mapping
+from typing import Sequence
+from typing import Tuple
+
+
+class Channel:
+    """One wearable slot with an ordered alphabet of physical labels."""
+
+    def __init__(self, name: str, labels: Sequence[str]):
+        labels = list(labels)
+        if len(labels) != len(set(labels)):
+            raise ValueError(f"channel {name!r} has duplicate labels: {labels}")
+        if not labels:
+            raise ValueError(f"channel {name!r} needs at least one label")
+        self.name = name
+        self.labels = labels
+        self._label_to_index = {label: i for i, label in enumerate(labels)}
+
+    def __repr__(self) -> str:
+        return f"Channel(name={self.name!r}, labels={self.labels!r})"
+
+    @property
+    def size(self) -> int:
+        """Number of labels available in this channel's alphabet."""
+        return len(self.labels)
+
+    def label_to_index(self, label: str) -> int:
+        try:
+            return self._label_to_index[label]
+        except KeyError:
+            raise ValueError(
+                f"channel {self.name!r} has no label {label!r}; known: {self.labels}"
+            )
+
+    def index_to_label(self, index: int) -> str:
+        if not 0 <= index < len(self.labels):
+            raise ValueError(
+                f"channel {self.name!r} index {index} out of range [0, {len(self.labels)})"
+            )
+        return self.labels[index]
+
+    def has_label(self, label: str) -> bool:
+        return label in self._label_to_index
+
+
+class ChannelSet:
+    """An ordered collection of channels backing a code of length ``n``.
+
+    ``q`` is the field cardinality (the common symbol count the code uses).
+    Every channel must supply at least ``q`` labels; only the first ``q`` are
+    addressable by codewords, but channels may carry extra labels.
+    """
+
+    def __init__(self, channels: Iterable[Channel], q: int):
+        channels = list(channels)
+        if not channels:
+            raise ValueError("ChannelSet needs at least one channel")
+        names = [c.name for c in channels]
+        if len(names) != len(set(names)):
+            raise ValueError(f"duplicate channel names: {names}")
+        for c in channels:
+            if c.size < q:
+                raise ValueError(
+                    f"channel {c.name!r} supplies {c.size} labels but q={q}; "
+                    "every channel must provide at least q symbols"
+                )
+        self.channels = channels
+        self.q = q
+
+    def __len__(self) -> int:
+        return len(self.channels)
+
+    def __iter__(self):
+        return iter(self.channels)
+
+    def __getitem__(self, index: int) -> Channel:
+        return self.channels[index]
+
+    @property
+    def n(self) -> int:
+        """Length (number of channels) -- must equal the code's ``n``."""
+        return len(self.channels)
+
+    @property
+    def names(self) -> List[str]:
+        return [c.name for c in self.channels]
+
+    def by_name(self, name: str) -> Channel:
+        for c in self.channels:
+            if c.name == name:
+                return c
+        raise ValueError(f"no channel named {name!r}; known: {self.names}")
+
+    def codeword_to_appearance(self, codeword: Sequence[int]) -> Dict[str, str]:
+        """Map a codeword (tuple of indices) to ``{channel_name: label}``."""
+        if len(codeword) != self.n:
+            raise ValueError(
+                f"codeword length {len(codeword)} != number of channels {self.n}"
+            )
+        return {
+            c.name: c.index_to_label(idx) for c, idx in zip(self.channels, codeword)
+        }
+
+    def appearance_to_codeword(self, appearance: Mapping[str, str]) -> Tuple[int, ...]:
+        """Map an appearance ``{channel_name: label}`` back to a codeword."""
+        missing = set(self.names) - set(appearance)
+        if missing:
+            raise ValueError(f"appearance missing channels: {sorted(missing)}")
+        return tuple(c.label_to_index(appearance[c.name]) for c in self.channels)

--- a/backend/identity/code.py
+++ b/backend/identity/code.py
@@ -1,0 +1,200 @@
+"""Linear block codes over ``GF(q)``.
+
+A :class:`LinearCode` is, abstractly, a set of codewords (length-``n`` tuples of
+symbols in ``[0, q)``) together with an ``encode`` map from messages. The
+decoder and scheme depend **only** on this abstract interface, so swapping the
+parity code for Reed-Solomon, adding a channel, or growing ``q`` constructs a
+*different* ``LinearCode`` and nothing downstream changes. That is the
+extensibility guarantee from the plan (§4).
+
+Two concrete families are provided via factories:
+
+* :func:`parity_code` -- the ``[n, n-1, 2]`` sum-parity code (the initial
+  ``parity_code(3, 5)`` config), and
+* :func:`reed_solomon_code` -- the ``[n, k, n-k+1]`` MDS code used for the
+  ``[4,2,3]`` / ``[5,2,4]`` upgrades.
+
+:func:`build_code` picks between them for a requested ``(n, q, target_distance)``
+and raises a clear error when the request is infeasible.
+"""
+
+from itertools import product
+from typing import Iterable
+from typing import Iterator
+from typing import List
+from typing import Tuple
+
+from backend.identity.galois import GF
+from backend.identity.galois import is_prime
+
+Codeword = Tuple[int, ...]
+Message = Tuple[int, ...]
+
+
+class LinearCode:
+    """A linear ``[n, k]`` code over ``GF(q)``.
+
+    Subclasses implement :meth:`encode`. Everything else (codeword enumeration,
+    minimum distance, syndrome-free membership test) is derived generically so
+    tests can assert the theoretical distance against a brute-force oracle.
+    """
+
+    def __init__(self, n: int, k: int, q: int):
+        if not is_prime(q):
+            raise ValueError(
+                f"q must be prime for the dependency-free GF(q); {q} is not prime"
+            )
+        if not 0 < k <= n:
+            raise ValueError(f"require 0 < k <= n; got n={n}, k={k}")
+        self.n = n
+        self.k = k
+        self.q = q
+        self.field = GF(q)
+
+    # -- abstract surface -------------------------------------------------
+
+    def encode(self, message: Message) -> Codeword:
+        """Map a length-``k`` message (symbols over ``GF(q)``) to a codeword."""
+        raise NotImplementedError
+
+    # -- derived surface --------------------------------------------------
+
+    @property
+    def capacity(self) -> int:
+        """Number of distinct codewords (= distinct identities), ``q**k``."""
+        return self.q**self.k
+
+    def messages(self) -> Iterator[Message]:
+        """Enumerate every length-``k`` message over ``GF(q)``."""
+        return product(range(self.q), repeat=self.k)
+
+    def codewords(self) -> Iterator[Codeword]:
+        """Enumerate every codeword (one per message)."""
+        for message in self.messages():
+            yield self.encode(message)
+
+    def is_codeword(self, word: Iterable[int]) -> bool:
+        """Return ``True`` if ``word`` is a valid codeword of this code."""
+        word = tuple(word)
+        if len(word) != self.n:
+            return False
+        return word in set(self.codewords())
+
+    def min_distance(self) -> int:
+        """Minimum Hamming distance, computed by brute force.
+
+        Fine for these tiny codes, and it doubles as the test oracle for the
+        theoretical ``d`` (``[3,2,2]``->2, ``[4,2,3]``->3, ``[5,2,4]``->4).
+        """
+        words: List[Codeword] = list(self.codewords())
+        best = self.n
+        for i in range(len(words)):
+            for j in range(i + 1, len(words)):
+                dist = sum(1 for a, b in zip(words[i], words[j]) if a != b)
+                if dist < best:
+                    best = dist
+        return best
+
+
+class ParityCode(LinearCode):
+    """The ``[n, n-1, 2]`` sum-parity code over ``GF(q)``.
+
+    The first ``n-1`` symbols are free (the message); the last symbol is chosen
+    so that ``sum(symbols) % q == 0``. Minimum distance is 2, so it can correct
+    one erasure *or* detect one misread.
+    """
+
+    def __init__(self, n: int, q: int):
+        if n < 2:
+            raise ValueError(f"parity code needs n >= 2; got n={n}")
+        super().__init__(n=n, k=n - 1, q=q)
+
+    def encode(self, message: Message) -> Codeword:
+        if len(message) != self.k:
+            raise ValueError(f"message must have length k={self.k}; got {len(message)}")
+        body = tuple(m % self.q for m in message)
+        parity = (-sum(body)) % self.q
+        return body + (parity,)
+
+
+class ReedSolomonCode(LinearCode):
+    """The ``[n, k, n-k+1]`` (MDS) Reed-Solomon code over ``GF(q)``.
+
+    A message ``(m_0, ..., m_{k-1})`` defines the polynomial
+    ``f(x) = m_0 + m_1 x + ... + m_{k-1} x^{k-1}``; the codeword is ``f``
+    evaluated at ``n`` distinct points of ``GF(q)``. Requires ``n <= q``.
+    """
+
+    def __init__(self, n: int, k: int, q: int, points: Iterable[int] = None):
+        if n > q:
+            raise ValueError(
+                f"Reed-Solomon requires n <= q (distinct eval points); got n={n}, q={q}"
+            )
+        super().__init__(n=n, k=k, q=q)
+        if points is None:
+            points = range(n)
+        self.points = tuple(p % q for p in points)
+        if len(set(self.points)) != n:
+            raise ValueError("Reed-Solomon evaluation points must be distinct")
+
+    def encode(self, message: Message) -> Codeword:
+        if len(message) != self.k:
+            raise ValueError(f"message must have length k={self.k}; got {len(message)}")
+        coeffs = [m % self.q for m in message]
+        word = []
+        for x in self.points:
+            acc = 0
+            power = 1
+            for c in coeffs:
+                acc = self.field.add(acc, self.field.mul(c, power))
+                power = self.field.mul(power, x)
+            word.append(acc)
+        return tuple(word)
+
+
+def parity_code(n: int, q: int) -> ParityCode:
+    """Build the ``[n, n-1, 2]`` sum-parity code over ``GF(q)``."""
+    return ParityCode(n=n, q=q)
+
+
+def reed_solomon_code(n: int, k: int, q: int) -> ReedSolomonCode:
+    """Build the ``[n, k, n-k+1]`` Reed-Solomon (MDS) code over ``GF(q)``."""
+    return ReedSolomonCode(n=n, k=k, q=q)
+
+
+def build_code(n: int, q: int, target_distance: int) -> LinearCode:
+    """Return a code over ``GF(q)`` of length ``n`` with distance
+    ``target_distance``, picking the simplest construction that achieves it.
+
+    * ``target_distance == 2`` -> parity code (maximises capacity at ``d=2``).
+    * ``target_distance > 2``  -> Reed-Solomon MDS code with ``k = n - d + 1``.
+
+    Raises a clear :class:`ValueError` when the request is infeasible:
+
+    * ``d`` must satisfy ``1 <= d <= n`` (the ``d <= n`` ceiling), and
+    * an MDS code needs ``n <= q`` and ``k = n - d + 1 >= 1``.
+    """
+    if target_distance < 1:
+        raise ValueError(f"target_distance must be >= 1; got {target_distance}")
+    if target_distance > n:
+        raise ValueError(
+            f"infeasible: minimum distance cannot exceed n ({target_distance} > {n}); "
+            "add channels (increase n) to buy more fault tolerance"
+        )
+    if target_distance == 1:
+        # d=1 is the trivial full code: every word is a codeword. Model it as a
+        # length-n parity-free code via Reed-Solomon with k=n.
+        return reed_solomon_code(n=n, k=n, q=q)
+    if target_distance == 2:
+        return parity_code(n=n, q=q)
+    k = n - target_distance + 1
+    if k < 1:
+        raise ValueError(
+            f"infeasible: k = n - d + 1 = {k} < 1 for n={n}, d={target_distance}"
+        )
+    if n > q:
+        raise ValueError(
+            f"infeasible: a d={target_distance} MDS code needs n <= q, but n={n} > q={q}; "
+            "increase the colour count q (to the next prime) or reduce n"
+        )
+    return reed_solomon_code(n=n, k=k, q=q)

--- a/backend/identity/config.py
+++ b/backend/identity/config.py
@@ -1,0 +1,86 @@
+"""The declarative initial configuration and a ``default_scheme()`` factory.
+
+Changing the initial setup = editing **this one file**: add a colour to the
+palette, add a :class:`Channel`, or switch the code to
+:func:`reed_solomon_code`. Nothing in :mod:`backend.identity.decoder`,
+:mod:`~backend.identity.scheme`, or :mod:`~backend.identity.channels` needs to
+change -- that is the extensibility guarantee.
+
+**The palette is a placeholder, not final** (plan §9): the five colours below
+are decent starting defaults. The genuinely best-distinguishable palette will be
+chosen by live camera tests with the real hardware, so keep swapping colours
+here a one-line change and do not treat these as fixed.
+"""
+
+from backend.identity.channels import Channel
+from backend.identity.channels import ChannelSet
+from backend.identity.code import build_code
+from backend.identity.code import parity_code
+from backend.identity.decoder import DecoderThresholds
+from backend.identity.scheme import IdentityScheme
+
+# Placeholder palette (see module docstring): red / yellow / green / blue /
+# purple. Index <-> colour: 0=red, 1=yellow, 2=green, 3=blue, 4=purple.
+DEFAULT_PALETTE = ["red", "yellow", "green", "blue", "purple"]
+
+# The field cardinality q = number of colours. 5 is prime, so the simple
+# dependency-free GF(q) arithmetic is valid.
+DEFAULT_Q = len(DEFAULT_PALETTE)
+
+# The wearable channels (slots). Initially three, all using the colour palette.
+# Add/remove/reorder channels here -- e.g. a "shape" channel with a shape
+# alphabet, or splitting the armband into left + right.
+DEFAULT_CHANNEL_NAMES = ["shirt", "head", "armband"]
+
+# Decoder flag thresholds (tune per field experience).
+DEFAULT_THRESHOLDS = DecoderThresholds(
+    confident_threshold=0.6,
+    ambiguous_margin=0.15,
+    epsilon=1e-6,
+)
+
+
+def default_channel_set(palette=None, channel_names=None, q=None) -> ChannelSet:
+    """Build the initial :class:`ChannelSet` (three colour channels)."""
+    palette = list(palette if palette is not None else DEFAULT_PALETTE)
+    channel_names = list(
+        channel_names if channel_names is not None else DEFAULT_CHANNEL_NAMES
+    )
+    q = q if q is not None else len(palette)
+    channels = [Channel(name=name, labels=palette) for name in channel_names]
+    return ChannelSet(channels=channels, q=q)
+
+
+def default_scheme() -> IdentityScheme:
+    """The initial scheme: 3 colour channels, 5 colours, ``[3,2,2]`` parity.
+
+    Capacity = ``5**2`` = **25** distinct player identities.
+    """
+    channels = default_channel_set()
+    code = parity_code(n=len(DEFAULT_CHANNEL_NAMES), q=DEFAULT_Q)
+    return IdentityScheme(channels=channels, code=code)
+
+
+def scheme_with_distance(target_distance: int, k: int = 2) -> IdentityScheme:
+    """Convenience for the upgrade ladder (plan §2.5): build a scheme whose code
+    achieves ``target_distance`` while keeping ``k`` free symbols (so the player
+    capacity ``q**k`` is unchanged -- the default ``k=2`` keeps capacity 25).
+
+    Holding ``k`` fixed means the channel count grows with the distance:
+    ``n = k + d - 1`` (the MDS/Singleton relation). The ladder is therefore
+
+    * ``d=2`` -> ``n=3`` -> ``[3,2,2]`` parity (the default),
+    * ``d=3`` -> ``n=4`` -> ``[4,2,3]`` Reed-Solomon,
+    * ``d=4`` -> ``n=5`` -> ``[5,2,4]`` Reed-Solomon.
+
+    Channels reuse the default palette; ``DEFAULT_CHANNEL_NAMES`` is extended
+    with generically-named channels as the count grows.
+    """
+    n = k + target_distance - 1
+    names = list(DEFAULT_CHANNEL_NAMES)
+    while len(names) < n:
+        names.append(f"channel{len(names) + 1}")
+    names = names[:n]
+    channels = default_channel_set(channel_names=names)
+    code = build_code(n=n, q=DEFAULT_Q, target_distance=target_distance)
+    return IdentityScheme(channels=channels, code=code)

--- a/backend/identity/decoder.py
+++ b/backend/identity/decoder.py
@@ -1,0 +1,195 @@
+"""The soft decoder: the heart of the module.
+
+Given a :class:`Reading` (what the vision model saw), a set of candidate
+players (each with their codeword), and an optional :class:`Prior` (e.g. GPS
+proximity), produce a ranked list of player posteriors plus flags that
+generalise the code's hard guarantees:
+
+* ``inconsistent`` -- the (un-erased) reading cannot be explained by any
+  codeword within the code's correction radius, i.e. a misread was *detected*
+  but cannot be auto-corrected (this is "detect a misread" for the parity code).
+* ``ambiguous`` -- the top two posteriors are within a margin (a tie).
+* ``confident`` -- the top posterior is above a threshold.
+
+The decoder is **completely independent** of the vision/LLM and the database:
+tests feed it ``Reading``\\s, candidate codewords, and priors directly.
+
+It combines two views:
+
+* a **soft** likelihood (confidence-weighted) that drives the ranking and lets
+  a GPS prior break ties or rescue the erasure-plus-misread compromise, and
+* a **hard-decision** analysis (nearest codeword over the readable channels)
+  that drives the ``inconsistent`` flag in line with coding theory
+  (``2t + e + 1 <= d``).
+"""
+
+from typing import Dict
+from typing import List
+from typing import Mapping
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+
+from backend.identity.channels import ChannelSet
+from backend.identity.observations import Prior
+from backend.identity.observations import Reading
+
+Codeword = Tuple[int, ...]
+
+
+class DecoderThresholds:
+    """Tunable thresholds for the decoder's flags (all config, plan §5.6)."""
+
+    def __init__(
+        self,
+        confident_threshold: float = 0.6,
+        ambiguous_margin: float = 0.15,
+        epsilon: float = 1e-6,
+    ):
+        self.confident_threshold = confident_threshold
+        self.ambiguous_margin = ambiguous_margin
+        self.epsilon = epsilon
+
+
+class DecodeResult:
+    """The decoder's output: a ranking plus flags."""
+
+    def __init__(
+        self,
+        ranked: List[Tuple[object, float]],
+        inconsistent: bool,
+        ambiguous: bool,
+        confident: bool,
+        min_distance_to_codeword: Optional[int],
+    ):
+        self.ranked = ranked
+        self.inconsistent = inconsistent
+        self.ambiguous = ambiguous
+        self.confident = confident
+        self.min_distance_to_codeword = min_distance_to_codeword
+
+    def __repr__(self) -> str:
+        return (
+            f"DecodeResult(ranked={self.ranked!r}, inconsistent={self.inconsistent}, "
+            f"ambiguous={self.ambiguous}, confident={self.confident})"
+        )
+
+    @property
+    def best(self) -> Optional[object]:
+        """The top-ranked player id, or ``None`` if there are no candidates."""
+        return self.ranked[0][0] if self.ranked else None
+
+    @property
+    def best_posterior(self) -> float:
+        return self.ranked[0][1] if self.ranked else 0.0
+
+
+def _hamming_distance(
+    reading: Reading,
+    codeword: Sequence[int],
+    channels: ChannelSet,
+) -> int:
+    """Hamming distance between the reading's hard-decision symbols and a
+    codeword, counted **over readable (non-erased) channels only**."""
+    dist = 0
+    for obs, channel, expected in zip(reading, channels, codeword):
+        best = obs.best_symbol(channel)
+        if best is None:  # erased -> contributes nothing
+            continue
+        if best != expected:
+            dist += 1
+    return dist
+
+
+def decode(
+    reading: Reading,
+    candidates: Mapping[object, Sequence[int]],
+    channels: ChannelSet,
+    prior: Optional[Prior] = None,
+    thresholds: Optional[DecoderThresholds] = None,
+    code_min_distance: Optional[int] = None,
+) -> DecodeResult:
+    """Decode a reading into a ranked list of candidate players.
+
+    Parameters
+    ----------
+    reading:
+        One :class:`ChannelObservation` per channel, in channel order.
+    candidates:
+        ``{player_id: codeword}`` -- the players in play and their codewords
+        (e.g. alive players on other teams).
+    channels:
+        The :class:`ChannelSet` (used to resolve symbol labels and ``q``).
+    prior:
+        Optional :class:`Prior` over the candidate players (defaults uniform).
+    thresholds:
+        Optional :class:`DecoderThresholds` (defaults to sensible values).
+    code_min_distance:
+        The code's minimum distance ``d`` (used for the ``inconsistent``
+        flag's correction-radius test). If omitted, the flag falls back to a
+        plain "no exact codeword match" check.
+    """
+    if len(reading) != channels.n:
+        raise ValueError(
+            f"reading has {len(reading)} channels but ChannelSet has {channels.n}"
+        )
+    thresholds = thresholds or DecoderThresholds()
+    prior = prior or Prior()
+    q = channels.q
+    floor = thresholds.epsilon
+
+    num_candidates = len(candidates)
+    uniform = 1.0 / num_candidates if num_candidates else 0.0
+
+    # -- soft likelihoods + prior -> posteriors ---------------------------
+    scores: Dict[object, float] = {}
+    for player_id, codeword in candidates.items():
+        if len(codeword) != channels.n:
+            raise ValueError(
+                f"candidate {player_id!r} codeword length {len(codeword)} != n {channels.n}"
+            )
+        likelihood = 1.0
+        for obs, channel, symbol in zip(reading, channels, codeword):
+            likelihood *= obs.symbol_weight(symbol, channel, q, floor)
+        scores[player_id] = prior.weight_for(player_id, uniform) * likelihood
+
+    total = sum(scores.values())
+    if total > 0:
+        ranked = [(pid, s / total) for pid, s in scores.items()]
+    else:
+        # Degenerate (all-zero): fall back to the prior alone, else uniform.
+        ranked = [(pid, prior.weight_for(pid, uniform)) for pid in candidates]
+        norm = sum(s for _, s in ranked) or 1.0
+        ranked = [(pid, s / norm) for pid, s in ranked]
+    ranked.sort(key=lambda item: item[1], reverse=True)
+
+    # -- hard-decision analysis for the inconsistent flag -----------------
+    min_dist: Optional[int] = None
+    if candidates:
+        min_dist = min(
+            _hamming_distance(reading, cw, channels) for cw in candidates.values()
+        )
+
+    num_erasures = reading.num_erasures
+    inconsistent = False
+    if min_dist is not None:
+        if code_min_distance is not None:
+            # Misreads correctable alongside e erasures: 2t + e + 1 <= d.
+            t = max((code_min_distance - 1 - num_erasures) // 2, 0)
+            inconsistent = min_dist > t
+        else:
+            inconsistent = min_dist > 0
+
+    # -- ambiguity / confidence ------------------------------------------
+    confident = bool(ranked) and ranked[0][1] >= thresholds.confident_threshold
+    ambiguous = (
+        len(ranked) >= 2 and (ranked[0][1] - ranked[1][1]) < thresholds.ambiguous_margin
+    )
+
+    return DecodeResult(
+        ranked=ranked,
+        inconsistent=inconsistent,
+        ambiguous=ambiguous,
+        confident=confident,
+        min_distance_to_codeword=min_dist,
+    )

--- a/backend/identity/galois.py
+++ b/backend/identity/galois.py
@@ -1,0 +1,69 @@
+"""Minimal prime-field ``GF(p)`` arithmetic.
+
+Pure Python, no dependencies. Only prime fields are supported (``p`` must be
+prime). This is all the algebra the parity *and* Reed-Solomon codes need.
+
+Non-prime prime powers (e.g. 4, 8, 9) would need ``GF(p^m)`` extension-field
+arithmetic, which is out of scope: round the colour count up to the next prime
+instead (see the plan, §3).
+"""
+
+
+def is_prime(n: int) -> bool:
+    """Return ``True`` if ``n`` is a prime number."""
+    if n < 2:
+        return False
+    if n < 4:
+        return True
+    if n % 2 == 0:
+        return False
+    i = 3
+    while i * i <= n:
+        if n % i == 0:
+            return False
+        i += 2
+    return True
+
+
+class GF:
+    """Arithmetic over the prime field ``GF(p)``.
+
+    Elements are plain ``int``s in ``[0, p)``. Every operation reduces its
+    result mod ``p``.
+    """
+
+    def __init__(self, p: int):
+        if not is_prime(p):
+            raise ValueError(f"GF(p) requires a prime modulus; {p} is not prime")
+        self.p = p
+
+    def __repr__(self) -> str:
+        return f"GF({self.p})"
+
+    def _check(self, a: int) -> int:
+        return a % self.p
+
+    def add(self, a: int, b: int) -> int:
+        return (a + b) % self.p
+
+    def sub(self, a: int, b: int) -> int:
+        return (a - b) % self.p
+
+    def neg(self, a: int) -> int:
+        return (-a) % self.p
+
+    def mul(self, a: int, b: int) -> int:
+        return (a * b) % self.p
+
+    def inv(self, a: int) -> int:
+        """Multiplicative inverse of ``a`` via Fermat's little theorem.
+
+        ``a^(p-2) == a^-1 (mod p)`` for non-zero ``a``.
+        """
+        a = self._check(a)
+        if a == 0:
+            raise ZeroDivisionError("0 has no multiplicative inverse in GF(p)")
+        return pow(a, self.p - 2, self.p)
+
+    def div(self, a: int, b: int) -> int:
+        return self.mul(a, self.inv(b))

--- a/backend/identity/observations.py
+++ b/backend/identity/observations.py
@@ -1,0 +1,165 @@
+"""Data types describing what the vision model *read*, plus priors.
+
+These are plain, dependency-free value objects. The decoder consumes them; the
+vision adapter (in the integration layer, not this package) produces them.
+
+A :class:`ChannelObservation` is, per channel, one of:
+
+* a **distribution** over that channel's alphabet -- ``{label_or_index: prob}``
+  (preferred: this is what a good vision model can emit), or
+* a single best ``symbol`` + ``confidence`` (convenience; internally expanded to
+  a distribution with ``confidence`` on the symbol and the remainder spread
+  uniformly over the other ``q-1`` symbols), or
+* an **erasure** -- the channel was unreadable / obscured.
+
+A :class:`Reading` is one observation per channel, in channel order. A
+:class:`Prior` is an optional ``{player_id: probability}`` weighting (e.g. from
+GPS proximity); it defaults to uniform over the candidate set.
+"""
+
+from typing import Dict
+from typing import List
+from typing import Mapping
+from typing import Optional
+from typing import Sequence
+from typing import Union
+
+Symbol = Union[int, str]
+
+
+class ChannelObservation:
+    """A single channel's reading: a distribution, a best-guess, or an erasure.
+
+    Construct via the factory classmethods :meth:`distribution`,
+    :meth:`best_guess`, or :meth:`erasure` rather than the raw initialiser.
+    """
+
+    def __init__(self, distribution: Optional[Dict[Symbol, float]]):
+        # ``None`` means erasure. Otherwise a {symbol: probability} mapping
+        # whose keys are resolved against the channel at decode time (a symbol
+        # may be a label string or an integer index).
+        self._distribution = distribution
+
+    def __repr__(self) -> str:
+        if self.is_erasure:
+            return "ChannelObservation(erasure)"
+        return f"ChannelObservation({self._distribution!r})"
+
+    @property
+    def is_erasure(self) -> bool:
+        return self._distribution is None
+
+    @classmethod
+    def erasure(cls) -> "ChannelObservation":
+        """The channel was obscured / unreadable."""
+        return cls(None)
+
+    @classmethod
+    def distribution(cls, dist: Mapping[Symbol, float]) -> "ChannelObservation":
+        """A full probability distribution over (some of) the channel's symbols.
+
+        Probabilities need not sum to 1 -- the decoder reads the weight on the
+        candidate's true symbol and floors absent symbols. Negative weights are
+        rejected.
+        """
+        dist = dict(dist)
+        if not dist:
+            raise ValueError("distribution observation needs at least one entry")
+        for sym, prob in dist.items():
+            if prob < 0:
+                raise ValueError(f"negative probability {prob} for symbol {sym!r}")
+        return cls(dist)
+
+    @classmethod
+    def best_guess(cls, symbol: Symbol, confidence: float) -> "ChannelObservation":
+        """A single best symbol with a confidence in ``[0, 1]``.
+
+        Stored as a one-entry distribution; the decoder spreads the residual
+        ``1 - confidence`` over the other symbols using the field size ``q``.
+        """
+        if not 0.0 <= confidence <= 1.0:
+            raise ValueError(f"confidence must be in [0, 1]; got {confidence}")
+        obs = cls({symbol: confidence})
+        obs._is_best_guess = True
+        return obs
+
+    # Internal flag distinguishing best_guess (residual spread by the decoder)
+    # from an explicit distribution (floored as-is).
+    _is_best_guess = False
+
+    def symbol_weight(self, symbol_index: int, channel, q: int, floor: float) -> float:
+        """Likelihood contribution for a candidate whose true symbol at this
+        channel has index ``symbol_index``.
+
+        * erasure -> ``1.0`` (no information),
+        * best_guess -> ``confidence`` on the matching symbol else
+          ``(1 - confidence) / (q - 1)``,
+        * distribution -> the weight assigned to that symbol (floored to
+          ``floor`` so a never-mentioned true symbol can still win on a prior).
+        """
+        if self.is_erasure:
+            return 1.0
+        resolved = self._resolve(channel)
+        if getattr(self, "_is_best_guess", False):
+            ((only_symbol, confidence),) = resolved.items()
+            if only_symbol == symbol_index:
+                return confidence
+            if q <= 1:
+                return floor
+            return max((1.0 - confidence) / (q - 1), floor)
+        return max(resolved.get(symbol_index, 0.0), floor)
+
+    def best_symbol(self, channel) -> Optional[int]:
+        """Hard-decision argmax symbol index, or ``None`` for an erasure."""
+        if self.is_erasure:
+            return None
+        resolved = self._resolve(channel)
+        return max(resolved, key=resolved.get)
+
+    def _resolve(self, channel) -> Dict[int, float]:
+        """Resolve symbol keys (labels or indices) to channel indices."""
+        out: Dict[int, float] = {}
+        for sym, prob in self._distribution.items():
+            if isinstance(sym, str):
+                idx = channel.label_to_index(sym)
+            else:
+                idx = int(sym)
+            out[idx] = out.get(idx, 0.0) + prob
+        return out
+
+
+class Reading:
+    """One :class:`ChannelObservation` per channel, in channel order."""
+
+    def __init__(self, observations: Sequence[ChannelObservation]):
+        self.observations: List[ChannelObservation] = list(observations)
+
+    def __len__(self) -> int:
+        return len(self.observations)
+
+    def __iter__(self):
+        return iter(self.observations)
+
+    def __getitem__(self, index: int) -> ChannelObservation:
+        return self.observations[index]
+
+    @property
+    def num_erasures(self) -> int:
+        return sum(1 for obs in self.observations if obs.is_erasure)
+
+
+class Prior:
+    """An optional ``{player_id: weight}`` prior over candidate players."""
+
+    def __init__(self, weights: Optional[Mapping] = None):
+        self.weights: Dict = dict(weights) if weights else {}
+        for player_id, w in self.weights.items():
+            if w < 0:
+                raise ValueError(f"negative prior weight {w} for player {player_id!r}")
+
+    def weight_for(self, player_id, default: float) -> float:
+        return self.weights.get(player_id, default)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.weights

--- a/backend/identity/scheme.py
+++ b/backend/identity/scheme.py
@@ -1,0 +1,119 @@
+"""``IdentityScheme``: binds a :class:`ChannelSet`, a :class:`LinearCode`, and a
+player-to-codeword assignment.
+
+A player's identity is stored as a stable integer **slot** in
+``[0, capacity)``. The codeword (and hence the physical *appearance*) is derived
+from the slot via the code's ``encode`` -- so the database only ever needs to
+remember the slot, not the colour palette. The slot ``s`` is interpreted as a
+base-``q`` message of length ``k`` and encoded.
+
+Note (plan §8.2): the scheme parameters (palette, channels, code) are
+effectively fixed for the life of a game, because changing them changes what
+every player must physically wear. Treat a parameter change as a new game
+setup, not a live migration.
+"""
+
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Mapping
+from typing import Sequence
+from typing import Tuple
+
+from backend.identity.channels import ChannelSet
+from backend.identity.code import LinearCode
+
+Codeword = Tuple[int, ...]
+
+
+class IdentityScheme:
+    """The binding of channels + code that turns slots into appearances."""
+
+    def __init__(self, channels: ChannelSet, code: LinearCode):
+        if channels.n != code.n:
+            raise ValueError(f"channel count {channels.n} != code length {code.n}")
+        if channels.q != code.q:
+            raise ValueError(f"channel q {channels.q} != code q {code.q}")
+        self.channels = channels
+        self.code = code
+
+    @property
+    def capacity(self) -> int:
+        """Maximum number of distinct player identities, ``q**k``."""
+        return self.code.capacity
+
+    # -- slot <-> message -------------------------------------------------
+
+    def _slot_to_message(self, slot: int) -> Tuple[int, ...]:
+        if not 0 <= slot < self.capacity:
+            raise ValueError(f"slot {slot} out of range [0, {self.capacity})")
+        q, k = self.code.q, self.code.k
+        digits: List[int] = []
+        for _ in range(k):
+            digits.append(slot % q)
+            slot //= q
+        return tuple(digits)
+
+    def _message_to_slot(self, message: Sequence[int]) -> int:
+        q = self.code.q
+        slot = 0
+        for digit in reversed(message):
+            slot = slot * q + (digit % q)
+        return slot
+
+    # -- public surface ---------------------------------------------------
+
+    def codeword_of_slot(self, slot: int) -> Codeword:
+        """Codeword (tuple of channel indices) for a player's slot."""
+        return self.code.encode(self._slot_to_message(slot))
+
+    def slot_of_codeword(self, codeword: Sequence[int]) -> int:
+        """Inverse of :meth:`codeword_of_slot` for a *valid* codeword.
+
+        The first ``k`` symbols of the codewords this scheme emits are the
+        message itself (both the parity and Reed-Solomon-at-``0..n-1``
+        constructions are systematic in their leading ``k`` positions for the
+        configs we use), so the slot is recovered from them. Raises if the word
+        is not a codeword of this scheme.
+        """
+        codeword = tuple(codeword)
+        if not self.code.is_codeword(codeword):
+            raise ValueError(f"{codeword} is not a valid codeword of this scheme")
+        # Find the message whose encoding matches (robust to non-systematic
+        # codes); brute force is cheap for these tiny capacities.
+        for message in self.code.messages():
+            if self.code.encode(message) == codeword:
+                return self._message_to_slot(message)
+        raise ValueError(f"{codeword} is not a valid codeword of this scheme")
+
+    def appearance_of_slot(self, slot: int) -> Dict[str, str]:
+        """What to physically wear: ``{channel_name: label}`` for a slot."""
+        return self.channels.codeword_to_appearance(self.codeword_of_slot(slot))
+
+    def assign(self, player_ids: Iterable) -> Dict:
+        """Deterministically assign each player a slot ``0, 1, 2, ...``.
+
+        Returns ``{player_id: slot}``. Raises if there are more players than
+        :attr:`capacity`. Order follows the iterable, so callers control which
+        player gets which slot.
+        """
+        player_ids = list(player_ids)
+        if len(player_ids) > self.capacity:
+            raise ValueError(
+                f"{len(player_ids)} players exceed scheme capacity {self.capacity}"
+            )
+        return {player_id: slot for slot, player_id in enumerate(player_ids)}
+
+    def codewords_for(self, assignment: Mapping) -> Dict:
+        """Map a ``{player_id: slot}`` assignment to ``{player_id: codeword}``."""
+        return {
+            player_id: self.codeword_of_slot(slot)
+            for player_id, slot in assignment.items()
+        }
+
+    def appearances_for(self, assignment: Mapping) -> Dict[object, Dict[str, str]]:
+        """Map a ``{player_id: slot}`` assignment to ``{player_id: appearance}``."""
+        return {
+            player_id: self.appearance_of_slot(slot)
+            for player_id, slot in assignment.items()
+        }

--- a/tests/test_identity_channels.py
+++ b/tests/test_identity_channels.py
@@ -1,0 +1,64 @@
+"""Tests for channels: label<->index round-trips, alphabet validation, and
+heterogeneous alphabets (a shape channel alongside colour channels)."""
+
+import pytest
+
+from backend.identity.channels import Channel
+from backend.identity.channels import ChannelSet
+
+PALETTE = ["red", "yellow", "green", "blue", "purple"]
+SHAPES = ["circle", "square", "triangle", "star", "cross"]
+
+
+def test_label_index_roundtrip():
+    channel = Channel("shirt", PALETTE)
+    for i, label in enumerate(PALETTE):
+        assert channel.label_to_index(label) == i
+        assert channel.index_to_label(i) == label
+
+
+def test_channel_rejects_unknown_label():
+    channel = Channel("shirt", PALETTE)
+    with pytest.raises(ValueError):
+        channel.label_to_index("octarine")
+
+
+def test_channel_rejects_duplicate_labels():
+    with pytest.raises(ValueError):
+        Channel("shirt", ["red", "red", "green"])
+
+
+def test_channelset_rejects_channel_with_too_few_labels():
+    short = Channel("armband", ["red", "yellow"])
+    with pytest.raises(ValueError):
+        ChannelSet([Channel("shirt", PALETTE), short], q=5)
+
+
+def test_channelset_rejects_duplicate_names():
+    with pytest.raises(ValueError):
+        ChannelSet([Channel("shirt", PALETTE), Channel("shirt", PALETTE)], q=5)
+
+
+def test_heterogeneous_alphabets():
+    # A colour channel and a shape channel of the same cardinality coexist.
+    cs = ChannelSet([Channel("shirt", PALETTE), Channel("shape", SHAPES)], q=5)
+    appearance = cs.codeword_to_appearance((0, 2))
+    assert appearance == {"shirt": "red", "shape": "triangle"}
+    assert cs.appearance_to_codeword(appearance) == (0, 2)
+
+
+def test_codeword_appearance_roundtrip():
+    cs = ChannelSet(
+        [Channel(name, PALETTE) for name in ["shirt", "head", "armband"]], q=5
+    )
+    codeword = (3, 1, 4)
+    appearance = cs.codeword_to_appearance(codeword)
+    assert appearance == {"shirt": "blue", "head": "yellow", "armband": "purple"}
+    assert cs.appearance_to_codeword(appearance) == codeword
+
+
+def test_channel_may_carry_extra_labels():
+    # 6 labels with q=5 is fine; only the first q are addressed by codewords.
+    cs = ChannelSet([Channel("shirt", PALETTE + ["orange"])], q=5)
+    assert cs.n == 1
+    assert cs[0].size == 6

--- a/tests/test_identity_code.py
+++ b/tests/test_identity_code.py
@@ -1,0 +1,84 @@
+"""Tests for the linear codes: capacity, minimum distance, encode round-trips,
+and infeasibility errors. The brute-force ``min_distance`` is the oracle for the
+theoretical distances."""
+
+import pytest
+
+from backend.identity.code import build_code
+from backend.identity.code import parity_code
+from backend.identity.code import reed_solomon_code
+
+
+def test_parity_code_3_5_basics():
+    code = parity_code(3, 5)
+    assert code.n == 3
+    assert code.k == 2
+    assert code.q == 5
+    assert code.capacity == 25
+    assert code.min_distance() == 2
+
+
+def test_parity_codewords_sum_to_zero_mod_q():
+    code = parity_code(3, 5)
+    words = list(code.codewords())
+    assert len(words) == 25
+    assert len(set(words)) == 25
+    for word in words:
+        assert sum(word) % 5 == 0
+
+
+def test_parity_encode_roundtrip_and_membership():
+    code = parity_code(3, 5)
+    for message in code.messages():
+        word = code.encode(message)
+        assert word[: code.k] == message  # systematic in the leading k
+        assert code.is_codeword(word)
+
+
+def test_parity_rejects_non_codeword():
+    code = parity_code(3, 5)
+    # (1, 1, 1) sums to 3, not 0 mod 5.
+    assert not code.is_codeword((1, 1, 1))
+
+
+def test_reed_solomon_distances():
+    assert reed_solomon_code(4, 2, 5).min_distance() == 3
+    assert reed_solomon_code(5, 2, 5).min_distance() == 4
+
+
+def test_reed_solomon_capacity_and_roundtrip():
+    code = reed_solomon_code(4, 2, 5)
+    assert code.capacity == 25
+    words = list(code.codewords())
+    assert len(set(words)) == 25
+    for message in code.messages():
+        assert code.encode(message) == code.encode(message)
+
+
+def test_build_code_picks_parity_for_d2():
+    code = build_code(3, 5, target_distance=2)
+    assert code.min_distance() == 2
+    assert code.capacity == 25
+
+
+def test_build_code_picks_rs_for_higher_distance():
+    code = build_code(4, 5, target_distance=3)
+    assert code.min_distance() == 3
+    code = build_code(5, 5, target_distance=4)
+    assert code.min_distance() == 4
+
+
+def test_build_code_rejects_distance_above_n():
+    # d <= n ceiling: d=4 at n=3 is infeasible.
+    with pytest.raises(ValueError):
+        build_code(3, 5, target_distance=4)
+
+
+def test_reed_solomon_rejects_n_greater_than_q():
+    with pytest.raises(ValueError):
+        reed_solomon_code(6, 2, 5)
+
+
+def test_build_code_rejects_rs_with_n_greater_than_q():
+    with pytest.raises(ValueError):
+        build_code(6, 5, target_distance=3)

--- a/tests/test_identity_decoder.py
+++ b/tests/test_identity_decoder.py
@@ -1,0 +1,208 @@
+"""Behavioural tests for the soft decoder -- the core of the module.
+
+These encode the coding-theory guarantees *and* the documented compromise so
+neither can regress silently. They are parametrised over two configs to prove
+the decoder is config-agnostic:
+
+* the initial ``[3,2,2]`` parity scheme, and
+* the ``[4,2,3]`` Reed-Solomon upgrade.
+
+No DB, no network, no Pillow: readings, candidates and priors are fed directly.
+"""
+
+import pytest
+
+from backend.identity.config import default_scheme
+from backend.identity.config import scheme_with_distance
+from backend.identity.decoder import DecoderThresholds
+from backend.identity.decoder import decode
+from backend.identity.observations import ChannelObservation
+from backend.identity.observations import Prior
+from backend.identity.observations import Reading
+
+HIGH = 0.9  # vision confidence for a clean per-channel read
+
+
+# -- helpers ----------------------------------------------------------------
+
+
+def all_candidates(scheme):
+    """``{slot: codeword}`` for every identity the scheme can express."""
+    return {slot: scheme.codeword_of_slot(slot) for slot in range(scheme.capacity)}
+
+
+def correct_obs(scheme, channel_index, symbol, confidence=HIGH):
+    channel = scheme.channels[channel_index]
+    return ChannelObservation.best_guess(channel.index_to_label(symbol), confidence)
+
+
+def reading_for(scheme, codeword, erase=(), misread=()):
+    """Build a Reading for a target ``codeword``.
+
+    ``erase`` -- channel indices reported as obscured.
+    ``misread`` -- channel indices reported as a (deterministic) wrong colour.
+    """
+    obs = []
+    for i, symbol in enumerate(codeword):
+        if i in erase:
+            obs.append(ChannelObservation.erasure())
+        elif i in misread:
+            wrong = (symbol + 1) % scheme.channels.q
+            obs.append(correct_obs(scheme, i, wrong))
+        else:
+            obs.append(correct_obs(scheme, i, symbol))
+    return Reading(obs)
+
+
+def run(scheme, reading, prior=None, candidates=None):
+    return decode(
+        reading,
+        candidates if candidates is not None else all_candidates(scheme),
+        scheme.channels,
+        prior=prior,
+        code_min_distance=scheme.code.min_distance(),
+    )
+
+
+# Param: (scheme factory, label) for the config-agnostic suite.
+SCHEMES = [
+    pytest.param(default_scheme, id="parity-3-2-2"),
+    pytest.param(lambda: scheme_with_distance(3), id="rs-4-2-3"),
+]
+
+
+# -- clean reading ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("make_scheme", SCHEMES)
+def test_clean_reading_identifies_player(make_scheme):
+    scheme = make_scheme()
+    target = 7
+    reading = reading_for(scheme, scheme.codeword_of_slot(target))
+    result = run(scheme, reading)
+    assert result.best == target
+    assert result.best_posterior > 0.99
+    assert result.confident
+    assert not result.inconsistent
+    assert not result.ambiguous
+
+
+# -- single erasure (erasure correction) ------------------------------------
+
+
+@pytest.mark.parametrize("make_scheme", SCHEMES)
+def test_single_erasure_is_corrected(make_scheme):
+    scheme = make_scheme()
+    target = 11
+    reading = reading_for(scheme, scheme.codeword_of_slot(target), erase=(1,))
+    result = run(scheme, reading)
+    assert result.best == target
+    assert not result.inconsistent  # erasure is correctable, not a fault
+    assert result.confident
+
+
+# -- single misread (detect vs correct, config-dependent) -------------------
+
+
+def test_single_misread_parity_is_detected():
+    # [3,2,2]: a lone misread cannot be corrected, only DETECTED -> inconsistent.
+    scheme = default_scheme()
+    target = 9
+    reading = reading_for(scheme, scheme.codeword_of_slot(target), misread=(0,))
+    result = run(scheme, reading)
+    assert result.inconsistent
+
+
+def test_single_misread_rs_is_corrected():
+    # [4,2,3]: d=3 corrects one misread -> right player, NOT flagged inconsistent.
+    scheme = scheme_with_distance(3)
+    target = 9
+    reading = reading_for(scheme, scheme.codeword_of_slot(target), misread=(0,))
+    result = run(scheme, reading)
+    assert result.best == target
+    assert not result.inconsistent
+
+
+# -- the compromise: erasure + misread on the parity code -------------------
+
+
+def test_parity_erasure_plus_misread_is_the_compromise():
+    # One hidden channel + one misread among the survivors: the parity code has
+    # no check left and can silently decode to the WRONG player. This test pins
+    # the documented limitation so it can't regress unnoticed.
+    scheme = default_scheme()
+    target = 12
+    reading = reading_for(
+        scheme, scheme.codeword_of_slot(target), erase=(0,), misread=(1,)
+    )
+    result = run(scheme, reading)
+    assert result.best != target  # the compromise: confidently wrong
+
+
+def test_gps_prior_recovers_the_compromise():
+    # ...but a GPS-style prior favouring the true player rescues it (soft decode).
+    scheme = default_scheme()
+    target = 12
+    reading = reading_for(
+        scheme, scheme.codeword_of_slot(target), erase=(0,), misread=(1,)
+    )
+    prior = Prior({target: 100.0})
+    result = run(scheme, reading, prior=prior)
+    assert result.best == target
+
+
+# -- prior breaks a tie -----------------------------------------------------
+
+
+def test_prior_breaks_an_ambiguous_tie():
+    scheme = default_scheme()
+    a, b = 3, 17
+    candidates = {a: scheme.codeword_of_slot(a), b: scheme.codeword_of_slot(b)}
+    # Everything erased -> the reading carries no information: a pure tie.
+    reading = Reading([ChannelObservation.erasure() for _ in range(scheme.channels.n)])
+
+    no_prior = run(scheme, reading, candidates=candidates)
+    assert no_prior.ambiguous
+    assert no_prior.ranked[0][1] == pytest.approx(no_prior.ranked[1][1])
+
+    primed = run(scheme, reading, prior=Prior({a: 10.0, b: 1.0}), candidates=candidates)
+    assert primed.best == a
+
+
+# -- distribution-style observations also work ------------------------------
+
+
+def test_distribution_observation_decodes():
+    scheme = default_scheme()
+    target = 5
+    codeword = scheme.codeword_of_slot(target)
+    obs = []
+    for i, symbol in enumerate(codeword):
+        channel = scheme.channels[i]
+        dist = {channel.index_to_label(symbol): 0.8}
+        # spread a little mass onto a neighbour to mimic a real model
+        other = (symbol + 2) % scheme.channels.q
+        dist[channel.index_to_label(other)] = 0.2
+        obs.append(ChannelObservation.distribution(dist))
+    result = run(scheme, Reading(obs))
+    assert result.best == target
+
+
+def test_thresholds_are_configurable():
+    scheme = default_scheme()
+    target = 1
+    reading = reading_for(scheme, scheme.codeword_of_slot(target))
+
+    def confident_under(threshold):
+        return decode(
+            reading,
+            all_candidates(scheme),
+            scheme.channels,
+            thresholds=DecoderThresholds(confident_threshold=threshold),
+            code_min_distance=scheme.code.min_distance(),
+        ).confident
+
+    # A loose threshold accepts the clean read; an impossibly strict one rejects
+    # it -- proving the flag thresholds are configuration, not hard-coded.
+    assert confident_under(0.6)
+    assert not confident_under(1.0 + 1e-9)

--- a/tests/test_identity_galois.py
+++ b/tests/test_identity_galois.py
@@ -1,0 +1,50 @@
+"""Field-axiom tests for the prime-field arithmetic (no DB, no network)."""
+
+import pytest
+
+from backend.identity.galois import GF
+from backend.identity.galois import is_prime
+
+
+@pytest.mark.parametrize("p", [2, 3, 5, 7, 11, 13])
+def test_is_prime_accepts_primes(p):
+    assert is_prime(p)
+
+
+@pytest.mark.parametrize("n", [0, 1, 4, 6, 8, 9, 15, 25])
+def test_is_prime_rejects_composites(n):
+    assert not is_prime(n)
+
+
+@pytest.mark.parametrize("p", [4, 6, 8, 9, 1, 0])
+def test_gf_rejects_composite_modulus(p):
+    with pytest.raises(ValueError):
+        GF(p)
+
+
+@pytest.mark.parametrize("p", [5, 7])
+def test_additive_inverse(p):
+    field = GF(p)
+    for a in range(p):
+        assert field.add(a, field.neg(a)) == 0
+
+
+@pytest.mark.parametrize("p", [5, 7])
+def test_multiplicative_inverse(p):
+    field = GF(p)
+    for a in range(1, p):
+        assert field.mul(a, field.inv(a)) == 1
+
+
+def test_zero_has_no_inverse():
+    field = GF(5)
+    with pytest.raises(ZeroDivisionError):
+        field.inv(0)
+
+
+def test_arithmetic_reduces_mod_p():
+    field = GF(5)
+    assert field.add(3, 4) == 2
+    assert field.sub(1, 3) == 3
+    assert field.mul(3, 4) == 2
+    assert field.div(3, 4) == field.mul(3, field.inv(4))

--- a/tests/test_identity_scheme.py
+++ b/tests/test_identity_scheme.py
@@ -1,0 +1,67 @@
+"""Tests for IdentityScheme: deterministic, unique assignment; capacity limits;
+and appearance<->codeword<->slot consistency."""
+
+import pytest
+
+from backend.identity.config import default_scheme
+from backend.identity.scheme import IdentityScheme
+
+
+def test_default_scheme_capacity():
+    scheme = default_scheme()
+    assert scheme.capacity == 25
+
+
+def test_assignment_is_deterministic_and_unique():
+    scheme = default_scheme()
+    players = [f"player-{i}" for i in range(25)]
+    assignment = scheme.assign(players)
+    assert assignment == scheme.assign(players)  # deterministic
+    slots = list(assignment.values())
+    assert sorted(slots) == list(range(25))  # unique, dense
+
+
+def test_assignment_rejects_too_many_players():
+    scheme = default_scheme()
+    with pytest.raises(ValueError):
+        scheme.assign([f"player-{i}" for i in range(26)])
+
+
+def test_slot_codeword_roundtrip():
+    scheme = default_scheme()
+    for slot in range(scheme.capacity):
+        codeword = scheme.codeword_of_slot(slot)
+        assert scheme.slot_of_codeword(codeword) == slot
+
+
+def test_appearance_matches_codeword():
+    scheme = default_scheme()
+    for slot in range(scheme.capacity):
+        codeword = scheme.codeword_of_slot(slot)
+        appearance = scheme.appearance_of_slot(slot)
+        assert scheme.channels.appearance_to_codeword(appearance) == codeword
+
+
+def test_every_appearance_satisfies_parity():
+    # For the [3,2,2] parity scheme, the colour indices sum to 0 mod 5.
+    scheme = default_scheme()
+    for slot in range(scheme.capacity):
+        codeword = scheme.codeword_of_slot(slot)
+        assert sum(codeword) % 5 == 0
+
+
+def test_appearances_are_all_distinct():
+    scheme = default_scheme()
+    appearances = scheme.appearances_for(scheme.assign([f"p{i}" for i in range(25)]))
+    seen = {tuple(sorted(a.items())) for a in appearances.values()}
+    assert len(seen) == 25
+
+
+def test_scheme_rejects_mismatched_channels_and_code():
+    from backend.identity.code import parity_code
+    from backend.identity.config import default_channel_set
+
+    channels = default_channel_set()  # n = 3
+    code = parity_code(4, 5)  # n = 4
+    with pytest.raises(ValueError):
+        IdentityScheme(channels=channels, code=code)


### PR DESCRIPTION
Implements the self-contained, dependency-free identity package from
docs/team_photo_identification_plan.md (commits 1-7: the priority pure
deliverable; DB/web/vision integration in §8 is intentionally deferred).

backend/identity/:
- galois.py    GF(p) prime-field arithmetic
- code.py      LinearCode + parity / Reed-Solomon factories + build_code
- channels.py  Channel / ChannelSet (label <-> GF(q) index)
- observations.py  per-channel readings (distribution / best-guess / erasure)
- scheme.py    IdentityScheme (channels + code + slot<->codeword assignment)
- decoder.py   soft decoder: readings + prior -> ranked posteriors + flags
- config.py    declarative initial config (3 channels, 5 colours, [3,2,2])
               and default_scheme() / scheme_with_distance() upgrade factory

The decoder/scheme depend only on the abstract LinearCode + ChannelSet, so
swapping parity for Reed-Solomon, adding channels, or growing q is a config
change with no downstream edits.

Tests (tests/test_identity_*.py, import only backend.identity; no DB, no
network, no Pillow): field axioms; code distances ([3,2,2]->2, [4,2,3]->3,
[5,2,4]->4) and infeasibility errors; channel round-trips and heterogeneous
alphabets; scheme assignment/appearance consistency; and the behavioural
decoder suite covering clean reads, single-erasure correction, misread
detect-vs-correct, the erasure+misread compromise and its GPS-prior rescue,
prior tie-breaking, run config-agnostically over the [3,2,2] and [4,2,3]
configs. 64 tests, all passing.